### PR TITLE
Add light style

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,23 @@
+function loadPage(section, page) {
+    let buttons = document.getElementById(section).getElementsByTagName("button");
+    let currSel;
+    for (let i in buttons) {
+        if (buttons[i].classList?.contains("sel-btn")) {
+            if (page - 1 == i) return;
+            else {
+                currSel = buttons[i];
+                break;
+            }
+        }
+    }
+
+    fetch(section + "_page" + page + ".html")
+        .then((response) => response.text())
+        .then((data) => {
+            document.getElementById(section + "-content").innerHTML = data;
+            if (currSel) {
+                currSel.classList.remove("sel-btn");
+            }
+            document.getElementById(section).getElementsByTagName("button")[page - 1].classList.add("sel-btn");
+        });
+}

--- a/app.js
+++ b/app.js
@@ -21,3 +21,17 @@ function loadPage(section, page) {
             document.getElementById(section).getElementsByTagName("button")[page - 1].classList.add("sel-btn");
         });
 }
+
+function activeSection(section) {
+    hideAll();
+
+    const targetSection = document.getElementById(section);
+    targetSection.style.display = "block";
+    targetSection.focus();
+}
+
+function hideAll() {
+    document.querySelectorAll(".section").forEach((s) => {
+        s.style.display = "none";
+    });
+}

--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,7 @@ write_header(){
 
 <head>
   <meta charset=\"utf-8\">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel=\"stylesheet\" type=\"text/css\" href=\"style.css\">
   <title>Gruvbox wallpapers</title>
   <script>

--- a/build.sh
+++ b/build.sh
@@ -26,36 +26,10 @@ write_header(){
 
 <head>
   <meta charset=\"utf-8\">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name='viewport' content='idth=device-width, initial-scale=1.0'>
   <link rel=\"stylesheet\" type=\"text/css\" href=\"style.css\">
   <title>Gruvbox wallpapers</title>
-  <script>
-    function loadPage(section, page) {
-      let buttons = document.getElementById(section ).getElementsByTagName('button');
-      let currSel;
-      for(let i in buttons){
-        if(buttons[i].classList?.contains('sel-btn')){
-          if(page-1 == i)
-            return;
-          else{
-            currSel = buttons[i];
-            break;
-          }
-        }
-
-      }
-
-      fetch(section + '_page' + page + '.html')
-        .then(response => response.text())
-        .then(data => {
-          document.getElementById(section + '-content').innerHTML = data;
-          if (currSel){
-            currSel.classList.remove('sel-btn');
-          }
-          document.getElementById(section).getElementsByTagName('button')[page-1].classList.add('sel-btn');
-        });
-    }
-  </script>
+  <script src='app.js' defer></script>
 </head>
 
 <body>

--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,7 @@ write_header(){
 }
 
 write_section_header(){
-  echo "<h2 id=\"s$1\" class=\"clickable\" onclick=\"activeSection('$2')\" >" >> $3
+  echo "<h2 class=\"clickable\ s$1\" onclick=\"activeSection('$2')\" >" >> $3
   echo "$2" | tr a-z A-Z  >> $3
   echo "</h2>" >> $3
 }

--- a/build.sh
+++ b/build.sh
@@ -142,7 +142,7 @@ do
 done
 
 echo "<script>
-  window.onload = function myFunc() {" >> ./index.html
+  window.onload = () => {" >> ./index.html
 
 for section in "${sections[@]}"; do
   echo "    loadPage('$section', 1);

--- a/build.sh
+++ b/build.sh
@@ -26,10 +26,10 @@ write_header(){
 
 <head>
   <meta charset=\"utf-8\">
-  <meta name='viewport' content='idth=device-width, initial-scale=1.0'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
   <link rel=\"stylesheet\" type=\"text/css\" href=\"style.css\">
   <title>Gruvbox wallpapers</title>
-  <script src='app.js' defer></script>
+  <script src='app.js'></script>
 </head>
 
 <body>
@@ -37,7 +37,7 @@ write_header(){
 }
 
 write_section_header(){
-  echo "<h2 class=\"clickable\ s$1\" onclick=\"activeSection('$2')\" >" >> $3
+  echo "<h2 class=\"clickable s$1\" onclick=\"activeSection('$2')\" >" >> $3
   echo "$2" | tr a-z A-Z  >> $3
   echo "</h2>" >> $3
 }
@@ -75,7 +75,7 @@ do
   subhtml="${section}_page${page}.html"
   touch ./$subhtml
 
-  echo "<div id=\"$section\" style={display : \"none\"}>" >> ./index.html
+  echo "<div class='section' id=\"$section\">" >> ./index.html
 
   echo "<div class=\"pager\">" >> ./index.html
   countImgs=$(find "$subdir" -type f | wc -l)
@@ -84,8 +84,8 @@ do
     echo "<button class=\"clickable\" onclick=\"loadPage('$section', $i)\">$i</button>" >> ./index.html
   done
   echo "</div>" >> ./index.html
-  echo "<div id=\"$section-content\">" >> ./index.html
-  echo "<div id=\"c\">" >> ./$subhtml
+  echo "<div  id=\"$section-content\">" >> ./index.html
+  echo "<div class='c'>" >> ./$subhtml
   for wallpaper in ${subdir}/*
   do
     if [ "$img_count" -ge $maxPerPage ]; then
@@ -96,7 +96,7 @@ do
       touch ./$subhtml
 
 
-      echo "<div id=\"c\">" >> ./$subhtml
+      echo "<div class='c'>" >> ./$subhtml
       img_count=0
     fi
 
@@ -117,26 +117,16 @@ done
 
 echo "<script>
   window.onload = () => {" >> ./index.html
-
+echo "console.log('fuck');" >> ./index.html
+echo "hideAll();" >> ./index.html
 for section in "${sections[@]}"; do
-  echo "    loadPage('$section', 1);
-    document.getElementById('$section').style.display = \"none\";
-  " >> ./index.html
+  echo "    loadPage('$section', 1);" >> ./index.html
 done
 
-echo "  
-  document.getElementById(\"${sections[0]}\").style.display = \"block\";
+echo "
+  activeSection(\"${sections[0]}\");
 }
-  function activeSection(section){">> ./index.html
 
-for section in "${sections[@]}"; do
-  echo "
-    document.getElementById('$section').style.display = \"none\";
-  " >> ./index.html
-done
-  echo "  document.getElementById(section).style.display = \"block\";
-document.getElementById(section).focus();
-  }
 </script>" >> ./index.html
 
 

--- a/style.css
+++ b/style.css
@@ -1,74 +1,85 @@
+:root {
+  color-scheme: light dark;
+  --bg-color: light-dark(#fbf1c7, #282828);
+  --fg-color: light-dark(#3c3836, #ebdbb2);
+
+
+  --bg-color-reverse: light-dark(#3c3836, #ebdbb2);
+  --fg-color-reverse: light-dark(#fbf1c7, #282828);
+
+  --bg-color-3: light-dark(#bdae93, #665c54);
+  --bg-color-hard: light-dark(#f9f5d7, #1d2021);
+  --gray: light-dark(#7c6f64, #a89984);
+}
+
 body {
-  color: #ebdbb2;
-  background-color: #282828;
+  background-color: var(--bg-color);
   padding-left: 15%;
   padding-right: 15%;
   font-family: "Curier New", monospace;
 }
 
-h1 {
-  background-color: #ebdbb2;
-  color: #282828;
-  text-align: center;
-  text-decoration: none;
-  /*border-radius: 8px; */
+* {
+  color: var(--fg-color);
 }
 
+h1,
 h2 {
-  background-color: #ebdbb2;
-  color: #282828;
+  background-color: var(--bg-color-reverse);
+  color: var(--fg-color-reverse);
   text-align: center;
   text-decoration: none;
-  /*border-radius: 8px; */
 }
 
-a {
-  color: #ebdbb2;
-}
-
-.showmore{
+.showmore {
   text-align: center;
-  background-color: #ebdbb2;
-  color: #282828;
+  background-color: var(--bg-color-reverse);
+  color: var(--fg-color-reverse);
 }
 
 #s1 {
   background-color: #d65d0e;
 }
+
 #s2 {
   background-color: #cc241d;
 }
+
 #s3 {
   background-color: #98971a;
 }
+
 #s4 {
   background-color: #d79921;
 }
+
 #s5 {
   background-color: #458588;
 }
+
 #s6 {
   background-color: #b16286;
 }
+
 #s7 {
   background-color: #689d6a;
 }
 
 #c {
   padding: 1em;
-  background-color: #665c54;
+  background-color: var(--bg-color-3);
   text-align: center;
   /*border-radius: 8px; */
 }
 
 img {
-  transition: all .2s ease-in-out; 
+  transition: all .2s ease-in-out;
 }
 
 img:hover {
-  transform: scale(1.5); 
+  transform: scale(1.5);
   border: none;
-  box-shadow: 5px 4px 10px #000000;
+  box-shadow: 5px 4px 10px black;
 
 }
 
@@ -77,38 +88,35 @@ img:hover {
   margin-bottom: 10px;
   padding: 5px;
   /*border-radius: 8px; */
-  color: #282828; 
+  color: var(--fg-color-reverse);
   /*display: flex;
   justify-content: center;*/
   text-align: center;
 }
 
 .pager button {
-  background-color: #ebdbb2; 
-  border: none; 
-  color: #282828; 
-  padding: 10px 20px; 
-  text-align: center; 
-  text-decoration: none; 
-  display: inline-block; 
-  font-size: 16px; 
+  background-color: var(--bg-color-reverse);
+  border: none;
+  color: var(--fg-color-reverse);
+  padding: 10px 20px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 16px;
   font-weight: 900;
-  margin: 4px 2px; 
-  cursor: pointer; 
-  /*border-radius: 8px; */
+  margin: 4px 2px;
+  cursor: pointer;
+
+  &.sel-btn {
+    background-color: var(--bg-color);
+    color: var(--fg-color);
+
+    border-color: var(--fg-color);
+    border-width: thick;
+    border-style: solid;
+  }
 }
-
-.sel-btn{
-  background-color: #282828 !important;
-  border-color: #ebdbb2 !important;
-  color: #ebdbb2 !important;
-  border-width: thick !important;
-  border-style: solid !important;
-}
-
-
 
 .clickable {
   cursor: pointer;
 }
-

--- a/style.css
+++ b/style.css
@@ -37,31 +37,31 @@ h2 {
   color: var(--fg-color-reverse);
 }
 
-#s1 {
+.s1 {
   background-color: #d65d0e;
 }
 
-#s2 {
+.s2 {
   background-color: #cc241d;
 }
 
-#s3 {
+.s3 {
   background-color: #98971a;
 }
 
-#s4 {
+.s4 {
   background-color: #d79921;
 }
 
-#s5 {
+.s5 {
   background-color: #458588;
 }
 
-#s6 {
+.s6 {
   background-color: #b16286;
 }
 
-#s7 {
+.s7 {
   background-color: #689d6a;
 }
 

--- a/style.css
+++ b/style.css
@@ -65,7 +65,7 @@ h2 {
   background-color: #689d6a;
 }
 
-#c {
+.c {
   padding: 1em;
   background-color: var(--bg-color-3);
   text-align: center;
@@ -119,4 +119,8 @@ img:hover {
 
 .clickable {
   cursor: pointer;
+}
+
+.section {
+  display: none;
 }


### PR DESCRIPTION
In this pull request:

- Add colors variables with `light-dark()` color function those are match browser theme
- Add `viewport` meta-tag, now it is look cooler on mobile (fix misspelling)
- Change `#s[1-7]` styles to `.s[1-7]`, because id is for unique elements, but colors will be repeated sooner
- Change `#c` to `.c`, same reason
- Change some named function to anonymous (sorry)
- Move JS script to its own file, change some functions
- Add `.section` class to not write `style='display: none;'`

Sorry for spamming PR, I found bugs after the PR creation